### PR TITLE
Fix hyperlink

### DIFF
--- a/Source/Core/CtrlrIDs.h
+++ b/Source/Core/CtrlrIDs.h
@@ -526,6 +526,7 @@ namespace Ids
 	DECLARE_ID (uiHyperlinkFitTextToSize);
 	DECLARE_ID (uiHyperlinkTextJustification);
 	DECLARE_ID (uiHyperlinkOpensUrl);
+	DECLARE_ID (uiHyperlinkUrl);
 
 	DECLARE_ID (uiXYSurfaceBgGradientType);
 	DECLARE_ID (uiXYSurfaceBackgroundColour1);

--- a/Source/Lua/JuceClasses/LCore.cpp
+++ b/Source/Lua/JuceClasses/LCore.cpp
@@ -240,7 +240,7 @@ void LGlobalFunctions::wrapForLua (lua_State *L)
     [
         def("getNativeKeyMapping", &getNativeKeyMapping)
         ,
-        def("console", (void (*) (const std::string &)) &LGlobalFunctions::console),
+        //def("console", (void (*) (const std::string &)) &LGlobalFunctions::console),
         def("console", (void (*) (const String &)) &LGlobalFunctions::console)
         ,
 		def("J", (const String (*) (const std::string &)) &LGlobalFunctions::toJuceString),

--- a/Source/Resources/XML/CtrlrIDs.xml
+++ b/Source/Resources/XML/CtrlrIDs.xml
@@ -491,7 +491,8 @@
   <id name="uiHyperlinkFitTextToSize"     text="Fit text to size" type="Bool"/>
   <id name="uiHyperlinkTextJustification" text="Text justification" type="VarText" defaults="@justification"/>
   <id name="uiHyperlinkOpensUrl"          text="Should the button actually open the web browser" type="Bool" />
-
+  <id name="uiHyperlinkUrl"               text="Hyperlink URL" type="Text"/>
+  
   <!-- XY Surface -->
   <id name="uiXYSurfaceBgGradientType"                text="Background gradient type"           type="VarNumeric" defaults="@gradient"/>
   <id name="uiXYSurfaceBackgroundColour1"             text="Background colour1"                 type="Colour"/>

--- a/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.cpp
+++ b/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.cpp
@@ -154,8 +154,18 @@ void CtrlrHyperlink::setComponentText (const String &componentText)
 
 void CtrlrHyperlink::buttonContentChanged()
 {
-	valueMap.copyFrom (owner.getProcessor().setValueMap (getProperty (Ids::uiButtonContent)));
+	const String buttonContent = getProperty(Ids::uiButtonContent);
+	valueMap.copyFrom (owner.getProcessor().setValueMap (buttonContent));
 	setComponentValue (0, false);
+	if (hyperlinkOpensUrl())
+	{
+		hyperlinkButton->setURL(URL(buttonContent));
+	}
+}
+
+bool CtrlrHyperlink::hyperlinkOpensUrl()
+{
+	return getProperty(Ids::uiHyperlinkOpensUrl);
 }
 
 void CtrlrHyperlink::valueTreePropertyChanged (ValueTree &treeWhosePropertyHasChanged, const Identifier &property)
@@ -170,7 +180,7 @@ void CtrlrHyperlink::valueTreePropertyChanged (ValueTree &treeWhosePropertyHasCh
 	}
 	else if (property == Ids::uiHyperlinkOpensUrl)
     {
-        hyperlinkButton->setURL (getProperty(property) ? URL(getProperty(property)) : URL(String::empty));
+        hyperlinkButton->setURL (hyperlinkOpensUrl() ? URL(getProperty(Ids::uiButtonContent)) : URL(String::empty));
     }
 	else if (property == Ids::uiHyperlinkFont
 		|| property == Ids::uiHyperlinkFitTextToSize

--- a/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.cpp
+++ b/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.cpp
@@ -157,15 +157,17 @@ void CtrlrHyperlink::buttonContentChanged()
 	const String buttonContent = getProperty(Ids::uiButtonContent);
 	valueMap.copyFrom (owner.getProcessor().setValueMap (buttonContent));
 	setComponentValue (0, false);
-	if (hyperlinkOpensUrl())
-	{
-		hyperlinkButton->setURL(URL(buttonContent));
-	}
 }
 
 bool CtrlrHyperlink::hyperlinkOpensUrl()
 {
 	return getProperty(Ids::uiHyperlinkOpensUrl);
+}
+
+void CtrlrHyperlink::setHyperlinkUrl(const String& newURL)
+{
+	hyperlinkButton->setURL(URL(newURL));
+	hyperlinkButton->setTooltip(newURL);
 }
 
 void CtrlrHyperlink::valueTreePropertyChanged (ValueTree &treeWhosePropertyHasChanged, const Identifier &property)
@@ -180,8 +182,14 @@ void CtrlrHyperlink::valueTreePropertyChanged (ValueTree &treeWhosePropertyHasCh
 	}
 	else if (property == Ids::uiHyperlinkOpensUrl)
     {
-        hyperlinkButton->setURL (hyperlinkOpensUrl() ? URL(getProperty(Ids::uiButtonContent)) : URL(String::empty));
+		setHyperlinkUrl(hyperlinkOpensUrl() ? getProperty(Ids::uiHyperlinkUrl) : String::empty);
     }
+	else if (property == Ids::uiHyperlinkUrl)
+	{
+		if (hyperlinkOpensUrl()) {
+			setHyperlinkUrl(getProperty(Ids::uiHyperlinkUrl));
+		}
+	}
 	else if (property == Ids::uiHyperlinkFont
 		|| property == Ids::uiHyperlinkFitTextToSize
 		|| property == Ids::uiHyperlinkTextJustification)

--- a/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.h
+++ b/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.h
@@ -28,7 +28,8 @@ public:
 	void valueTreeChildOrderChanged (ValueTree& parentTreeWhoseChildrenHaveMoved, int, int){}
 	void customLookAndFeelChanged(LookAndFeelBase *customLookAndFeel = nullptr) {}
 	void buttonContentChanged();
-    //[/UserMethods]
+	bool hyperlinkOpensUrl();
+	//[/UserMethods]
 
     void paint (Graphics& g);
     void resized();

--- a/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.h
+++ b/Source/UIComponents/CtrlrComponents/Buttons/CtrlrHyperlink.h
@@ -29,6 +29,7 @@ public:
 	void customLookAndFeelChanged(LookAndFeelBase *customLookAndFeel = nullptr) {}
 	void buttonContentChanged();
 	bool hyperlinkOpensUrl();
+	void setHyperlinkUrl(const String &newURL);
 	//[/UserMethods]
 
     void paint (Graphics& g);


### PR DESCRIPTION
Hi atom,

This is a fix for the hyperlink button that has been broken (the actual link to URL part) for quite some time now (since this commit back in 2015 :"Added MIDI messaes to Hyperlink button (requested) this works the same way as a normal button just fill the content as for any button and clicking on the hyperlink will send the message if you want to open the URL anyway there is a special option for that now." ;-)

I haven't been able to update the BinaryData class since Ctrlr.jucer file doesn't seem to be available in the repository...
Am I missing something or has just the file been forgotten from source control ?

Thank you for your help !

Fredo.