### PR TITLE
Use JUCE to resolve the executable file name.

### DIFF
--- a/Source/Native/CtrlrLinux.cpp
+++ b/Source/Native/CtrlrLinux.cpp
@@ -128,7 +128,8 @@ const Result CtrlrLinux::getDefaultPanel(MemoryBlock& dataToWrite)
 	temp.loadFileAsData (dataToWrite);
 	return (Result::ok());
 #endif
-	libr_file *handle = libr_open (nullptr, LIBR_READ);
+	libr_file *handle = libr_open ( File::getSpecialLocation(File::hostApplicationPath).getFullPathName().toUTF8().getAddress(),
+					LIBR_READ);
 
 	if (handle == nullptr)
 	{
@@ -191,7 +192,8 @@ const Result CtrlrLinux::getDefaultResources(MemoryBlock& dataToWrite)
 	}
 #endif
 
-    libr_file *handle = libr_open (nullptr, LIBR_READ);
+    libr_file *handle = libr_open (File::getSpecialLocation(File::hostApplicationPath).getFullPathName().toUTF8().getAddress(),
+				   LIBR_READ);
 
 	if (handle == nullptr)
 	{
@@ -224,7 +226,7 @@ const Result CtrlrLinux::getDefaultResources(MemoryBlock& dataToWrite)
 
 const Result CtrlrLinux::getSignature(MemoryBlock &dataToWrite)
 {
-    libr_file *handle = libr_open (nullptr, LIBR_READ);
+    libr_file *handle = libr_open (File::getSpecialLocation(File::hostApplicationPath).getFullPathName().toUTF8().getAddress(), LIBR_READ);
 
 	if (handle == nullptr)
 	{


### PR DESCRIPTION
Read access to /proc/self/exe is not allowed on all systems as it might be a security risk. So on some systems Ctrlr crashes and ends up in an infinite loop, as it tries to get the crash dialog from the resources which are not available.

This patch addresses the primary problem which has been solved in JUCE already. The mentioned security risk above is a jail break. JUCE resolves all symbolic when it tries to find out the executable name. So the file is always accessed with respect to the current chroot environment, which is sufficiently safe to be allowed by the OS, docker or whatever is active.

The problem with the endless loops when the ressources can not be accessed remains for future work.

This patch should solve https://github.com/RomanKubiak/ctrlr/issues/100