### PR TITLE
Fix macOS build

### DIFF
--- a/Builds/MacOSX/Ctrlr.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX/Ctrlr.xcodeproj/project.pbxproj
@@ -2859,6 +2859,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -2874,7 +2875,7 @@
 				LIBRARY_STYLE = Bundle;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-bundle -lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;
@@ -2928,6 +2929,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -2943,7 +2945,7 @@
 				LIBRARY_STYLE = Bundle;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-bundle -lCtrlr";
 				OTHER_REZFLAGS = "-d ppc_$ppc -d i386_$i386 -d ppc64_$ppc64 -d x86_64_$x86_64 -I /System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers -I \"$(DEVELOPER_DIR)/Extras/CoreAudio/AudioUnits/AUPublic/AUBase\" -I \"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Headers\"";
@@ -2996,6 +2998,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3009,7 +3012,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				LIBRARY_STYLE = Bundle;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-bundle -lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;
@@ -3061,6 +3064,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3074,7 +3078,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				LIBRARY_STYLE = Bundle;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-bundle -lCtrlr";
 				OTHER_REZFLAGS = "-d ppc_$ppc -d i386_$i386 -d ppc64_$ppc64 -d x86_64_$x86_64 -I /System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers -I \"$(DEVELOPER_DIR)/Extras/CoreAudio/AudioUnits/AUPublic/AUBase\" -I \"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Headers\"";
@@ -3126,6 +3130,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3139,7 +3144,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;
@@ -3192,6 +3197,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3207,7 +3213,7 @@
 				LIBRARY_STYLE = Bundle;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-bundle -lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;
@@ -3260,6 +3266,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3273,7 +3280,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr.CtrlrAUv3;
@@ -3323,6 +3330,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3335,7 +3343,7 @@
 				INFOPLIST_FILE = Info-Standalone_Plugin.plist;
 				INFOPLIST_PREPROCESS = NO;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;
@@ -3436,6 +3444,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3448,7 +3457,7 @@
 				INFOPLIST_FILE = Info-AUv3_AppExtension.plist;
 				INFOPLIST_PREPROCESS = NO;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr.CtrlrAUv3;
@@ -3499,6 +3508,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3511,7 +3521,7 @@
 				INSTALL_PATH = "@executable_path/../Frameworks";
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;
 				PRODUCT_NAME = "Ctrlr";
@@ -3562,6 +3572,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3573,7 +3584,7 @@
 				);
 				INSTALL_PATH = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;
 				PRODUCT_NAME = "Ctrlr";
@@ -3688,6 +3699,7 @@
 					"$(SRCROOT)/../../Source/Misc/luabind",
 					"$(SRCROOT)/../../Source/Misc/libusb/include",
 					"$(SRCROOT)/../../Source/Misc/boost",
+					"$(SRCROOT)/../../Source/Misc/vst2sdk",
 					"$(SRCROOT)/../../Source/MIDI",
 					"$(SRCROOT)/../../Source/Core",
 					"$(SRCROOT)/../../Source/Native",
@@ -3701,7 +3713,7 @@
 				INFOPLIST_PREPROCESS = NO;
 				LIBRARY_STYLE = Bundle;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../JUCE/modules/juce_audio_processors/format_types/VST3_SDK $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../JUCE/modules $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Misc $(SRCROOT)/../../Source/Misc/include $(SRCROOT)/../../Source/Misc/lua/include $(SRCROOT)/../../Source/Misc/luabind $(SRCROOT)/../../Source/Misc/libusb/include $(SRCROOT)/../../Source/Misc/boost $(SRCROOT)/../../Source/Misc/vst2sdk $(SRCROOT)/../../Source/MIDI $(SRCROOT)/../../Source/Core $(SRCROOT)/../../Source/Native $(SRCROOT)/../../Source/Plugin $(SRCROOT)/../../Source/UIComponents $(SRCROOT)/../../Source/Lua $(SRCROOT)/../../JUCE/modules/juce_audio_plugin_client";
 				OTHER_CPLUSPLUSFLAGS = "-w";
 				OTHER_LDFLAGS = "-bundle -lCtrlr";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instigator.Ctrlr;

--- a/Builds/MacOSX/Info-AU.plist
+++ b/Builds/MacOSX/Info-AU.plist
@@ -37,7 +37,7 @@
         <key>manufacturer</key>
         <string>inSt</string>
         <key>type</key>
-        <string>CtrlrAU</string>
+        <string>aumi</string>
         <key>subtype</key>
         <string>cTrl</string>
         <key>version</key>

--- a/Builds/MacOSX/Info-AUv3_AppExtension.plist
+++ b/Builds/MacOSX/Info-AUv3_AppExtension.plist
@@ -45,7 +45,7 @@
             <key>manufacturer</key>
             <string>inSt</string>
             <key>type</key>
-            <string>CtrlrAU</string>
+            <string>aumi</string>
             <key>subtype</key>
             <string>cTrl</string>
             <key>version</key>

--- a/Ctrlr.jucer
+++ b/Ctrlr.jucer
@@ -10,7 +10,7 @@
               pluginIsSynth="1" pluginWantsMidiIn="1" pluginProducesMidiOut="1"
               pluginIsMidiEffectPlugin="1" pluginEditorRequiresKeys="1" pluginAUExportPrefix="CtrlrAU"
               pluginRTASCategory="" aaxIdentifier="com.instigator.Ctrlr" pluginAAXCategory="2"
-              companyName="Instigator" pluginAUMainType="CtrlrAU" pluginFormats="buildVST,buildVST3,buildAU,buildAUv3,buildStandalone"
+              companyName="Instigator" pluginFormats="buildVST,buildVST3,buildAU,buildAUv3,buildStandalone"
               pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn,pluginProducesMidiOut,pluginIsMidiEffectPlugin,pluginEditorRequiresKeys"
               jucerFormatVersion="1">
   <MAINGROUP id="SRLsFb" name="Ctrlr">
@@ -1060,9 +1060,9 @@
                enableGNUExtensions="0" extraCompilerFlags="-w">
       <CONFIGURATIONS>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="Ctrlr"
-                       headerPath="../../Source&#10;../../Source/Misc&#10;../../Source/Misc/include&#10;../../Source/Misc/lua/include&#10;../../Source/Misc/luabind&#10;../../Source/Misc/libusb/include&#10;../../Source/Misc/boost&#10;../../Source/MIDI&#10;../../Source/Core&#10;../../Source/Native&#10;../../Source/Plugin&#10;../../Source/UIComponents&#10;../../Source/Lua"/>
+                       headerPath="../../Source&#10;../../Source/Misc&#10;../../Source/Misc/include&#10;../../Source/Misc/lua/include&#10;../../Source/Misc/luabind&#10;../../Source/Misc/libusb/include&#10;../../Source/Misc/boost&#10;../../Source/Misc/vst2sdk&#10;../../Source/MIDI&#10;../../Source/Core&#10;../../Source/Native&#10;../../Source/Plugin&#10;../../Source/UIComponents&#10;../../Source/Lua"/>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="Ctrlr"
-                       headerPath="../../Source&#10;../../Source/Misc&#10;../../Source/Misc/include&#10;../../Source/Misc/lua/include&#10;../../Source/Misc/luabind&#10;../../Source/Misc/libusb/include&#10;../../Source/Misc/boost&#10;../../Source/MIDI&#10;../../Source/Core&#10;../../Source/Native&#10;../../Source/Plugin&#10;../../Source/UIComponents&#10;../../Source/Lua"
+                       headerPath="../../Source&#10;../../Source/Misc&#10;../../Source/Misc/include&#10;../../Source/Misc/lua/include&#10;../../Source/Misc/luabind&#10;../../Source/Misc/libusb/include&#10;../../Source/Misc/boost&#10;../../Source/Misc/vst2sdk&#10;../../Source/MIDI&#10;../../Source/Core&#10;../../Source/Native&#10;../../Source/Plugin&#10;../../Source/UIComponents&#10;../../Source/Lua"
                        enablePluginBinaryCopyStep="0"/>
       </CONFIGURATIONS>
       <MODULEPATHS>

--- a/JuceLibraryCode/JucePluginDefines.h
+++ b/JuceLibraryCode/JucePluginDefines.h
@@ -92,7 +92,7 @@
  #define JucePlugin_Vst3Category           "Instrument|Synth"
 #endif
 #ifndef  JucePlugin_AUMainType
- #define JucePlugin_AUMainType             CtrlrAU
+ #define JucePlugin_AUMainType             'aumi'
 #endif
 #ifndef  JucePlugin_AUSubType
  #define JucePlugin_AUSubType              JucePlugin_PluginCode

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Control any MIDI enabled hardware: synthesizers, drum machines, samplers, effect
 
 Cross Platform
 ==============
-Works on Windows (XP and up, both 64 and 32bit binaries are available), MAC OSX (10.5 and up), Linux (any modern distro should run it).
+Works on Windows (XP and up, both 64 and 32bit binaries are available), macOS (10.5 and up), Linux (any modern distro should run it).
 Host in your DAW
 
-Each platform has a VST build of Ctrlr so you can host your panels as normal VST plugins, for the OSX a special AU build is available.
+Each platform has a VST build of Ctrlr so you can host your panels as normal VST plugins, for macOS a special AU build is available.
 
 Customize
 =========
@@ -71,15 +71,17 @@ The post-commit script takes an argument "clean" if you wish to clean all the in
 files before building. If you want to ignore any package errors that it reports (i assume you
 know your system better then my script) then just add -f as an option when building.
 
-OSX
-===
-You need the CoreAudio developer files for the build to work.
+macOS
+=====
+Unzip boost or link your own boost library e.g. from [Homebrew](https://brew.sh):
 
-First you need to build the AU_wrapper library that simplifies the build a lot, it's located in
-Builds/Generated/Mac/AU_Wrapper, it will create a .a library and try to put it in /usr/local/lib
-if it fails, do that manualy (permission problems)
+```
+# use packaged boost library
+cd Source/Misc/boost && unzip boost.zip
+# alternatively, link your own
+ln -s /opt/homebrew/Cellar/boost/BOOST_VERSION/include/boost Source/Misc/boost/boost
+```
 
-Open the corresponding Xcode project in Builds/Generated/Mac, after that just build it, in case of
-errors you are on your own, the amount of changes between Xcode versions and OSX versions is impossible
-for me to track, you can post an issue and i'll try to solve it.
+Open the Xcode project `Builds/MacOSX/Ctrlr.xcodeproj` and build it.
 
+In case of errors it might help to refresh the project files using Projuicer.

--- a/Source/Native/CtrlrMac.cpp
+++ b/Source/Native/CtrlrMac.cpp
@@ -2,6 +2,7 @@
 #include "stdafx_luabind.h"
 static const int zero=0;
 #ifdef __APPLE__
+#include <memory>
 #include "CtrlrPanel/CtrlrPanel.h"
 #include "CtrlrMac.h"
 #include "CtrlrMacros.h"
@@ -126,7 +127,7 @@ const Result CtrlrMac::setBundleInfo (CtrlrPanel *sourceInfo, const File &bundle
 
 	if (plist.existsAsFile() && plist.hasWriteAccess())
 	{
-		ScopedPointer <XmlElement> plistXml (XmlDocument::parse(plist));
+		std::unique_ptr <XmlElement> plistXml (XmlDocument::parse(plist));
 		if (plistXml == nullptr)
 		{
 			return (Result::fail("MAC native, can't parse Info.plist as a XML document"));


### PR DESCRIPTION
With these changes I managed to compile natively for Apple Silicon. The build environment is:
- MacBook Air M1
- macOS 11.6
- Xcode 13.0

The previous AU type 'CtrlrAU' did not seem to work at all and led to a mysterious error from the resource compiler `Rez`. I have chosen to use the default `kAudioUnitType_MIDIProcessor` (`aumi`) which seems to fit well.

The standalone version seems to work very well using the OB-6 panel. Using the AU as a MIDI FX in an external MIDI track in Logic Pro generally works but there still seem to be a few bugs to be ironed out (or I haven't figured out how to configure it properly).