### PR TITLE
setModulatorValue: make "ui" flag working again, because MIDIbox pane…

### DIFF
--- a/Source/Core/CtrlrModulator/CtrlrModulatorProcessor.cpp
+++ b/Source/Core/CtrlrModulator/CtrlrModulatorProcessor.cpp
@@ -46,7 +46,7 @@ void CtrlrModulatorProcessor::handleAsyncUpdate()
 		owner.setProperty (Ids::modulatorValue, currentValue.value);
 	}
 
-	if (valueChangedCbk.get() && !owner.getRestoreState())
+	if (valueChangedCbk.get() && !owner.getRestoreState() && currentValue.lastChangeSource != CtrlrModulatorValue::changedByProgram)
 	{
 		CtrlrPanel &ownerPanel = owner.getOwnerPanel();
 		if (!ownerPanel.getRestoreState() && !ownerPanel.getBootstrapState() && valueChangedCbk->isValid())

--- a/Source/Lua/CtrlrLuaManager.cpp
+++ b/Source/Lua/CtrlrLuaManager.cpp
@@ -1067,7 +1067,7 @@ void CtrlrModulator::setValueNonMapped (const int newValue, const bool force, co
 
 void CtrlrModulator::setModulatorValue(const int newValue, bool vst, bool midi, bool ui)
 {
-	processor.setValueGeneric (CtrlrModulatorValue (newValue, CtrlrModulatorValue::changedByLua), true, !midi);
+  processor.setValueGeneric (CtrlrModulatorValue (newValue, ui ? CtrlrModulatorValue::changedByProgram : CtrlrModulatorValue::changedByLua), true, !midi);
 }
 
 int CtrlrModulator::getValueMapped() const


### PR DESCRIPTION
Make https://ctrlr.org/forums/topic/midibox-sid-v2-panel/ working again

MIDIbox panels rely on this to avoid feedback loops between LUA and (delayed) UI
